### PR TITLE
Move the Apollo server URI in env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 REACT_APP_SENTRY=<sentry_dsn>
+REACT_APP_APOLLO_SERVER_URI=<apollo_server_uri>

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -8,7 +8,7 @@ import { Home } from '../home/Home';
 
 // uri needs changing to the real thing when we're ready
 const client = new ApolloClient({
-  uri: 'https://48p1r2roz4.sse.codesandbox.io'
+  uri: process.env.REACT_APP_APOLLO_SERVER_URI
 });
 
 export const App = () => (


### PR DESCRIPTION
As per subject, move configuration vars outside of the code and into either `.env` files or `ENV` variables.

Development `.env` file not included, `.env.example` updated with the list of `ENV` vars currently in use.